### PR TITLE
BUGFIX: Fix behavior of "discard selected changes" button in workspace module

### DIFF
--- a/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
+++ b/Neos.Neos/Resources/Private/Templates/Module/Management/Workspaces/Show.html
@@ -8,7 +8,7 @@
 
 	<f:if condition="{siteChanges}">
 		<f:then>
-			<f:form action="publishOrDiscardNodes">
+			<f:form id="publishOrDiscardNodes" action="publishOrDiscardNodes">
 				<f:form.hidden name="selectedWorkspace" value="{selectedWorkspace}"/>
 				<legend>{neos:backend.translate(id: 'workspaces.unpublishedChanges', source: 'Modules', package: 'Neos.Neos', arguments: {0: selectedWorkspaceLabel})}</legend>
 				<br />
@@ -106,6 +106,25 @@
 				<div class="neos-modal-backdrop neos-in"></div>
 			</div>
 
+			<div class="neos-hide" id="discardSelected">
+				<div class="neos-modal-centered">
+					<div class="neos-modal-content">
+						<div class="neos-modal-header">
+							<button type="button" class="neos-close neos-button" data-dismiss="modal"></button>
+							<div class="neos-header">{neos:backend.translate(id: 'workspaces.discardSelectedChangesInWorkspaceConfirmation', arguments: {0: selectedWorkspaceLabel}, source: 'Modules', package: 'Neos.Neos')}</div>
+						</div>
+						<div class="neos-modal-footer">
+							<a href="#" class="neos-button" data-dismiss="modal">{neos:backend.translate(id: 'cancel', source: 'Main', package: 'Neos.Neos')}</a>
+							<button form="publishOrDiscardNodes" name="moduleArguments[action]" value="discard" type="submit" class="neos-button neos-button-danger">
+								<i class="fas fa-trash-alt icon-white"></i>
+								{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
+							</button>
+						</div>
+					</div>
+				</div>
+				<div class="neos-modal-backdrop neos-in"></div>
+			</div>
+
 			<f:form action="index" id="postHelper" method="post"></f:form>
 
 			<script>
@@ -188,26 +207,26 @@
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardAllChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="review-button-action neos-button neos-button-primary">
+					<button form="postHelper" formaction="{f:uri.action(action: 'publishWorkspace', arguments: {workspace: selectedWorkspace})}" type="submit" class="review-button-action neos-button neos-button-success">
 						<i class="fas fa-check-double icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishAllChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
-					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discard">
+					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discardSelected">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-primary neos-hidden neos-disabled batch-action" disabled="disabled">
-						<li class="fas fa-check icon-white"></li>
+					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-success neos-hidden neos-disabled batch-action" disabled="disabled">
+						<i class="fas fa-check icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
 				</f:then>
 				<f:else>
-					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discard">
+					<button type="submit" name="moduleArguments[action]" value="discard" class="neos-button neos-button-danger neos-hidden neos-disabled batch-action" disabled="disabled" data-toggle="modal" href="#discardSelected">
 						<i class="fas fa-trash-alt icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.discardSelectedChanges', source: 'Modules', package: 'Neos.Neos')}
 					</button>
-					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-primary neos-hidden neos-disabled batch-action" disabled="disabled">
-						<li class="fas fa-check icon-white"></li>
+					<button type="submit" name="moduleArguments[action]" value="publish" class="neos-button neos-button-success neos-hidden neos-disabled batch-action" disabled="disabled">
+						<i class="fas fa-check icon-white"></i>
 						{neos:backend.translate(id: 'workspaces.publishSelectedChangesTo', source: 'Modules', package: 'Neos.Neos', arguments: {0: baseWorkspaceLabel})}
 					</button>
 					<button class="review-button-action neos-button neos-button-danger" data-toggle="modal" href="#discard">

--- a/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/de/Modules.xlf
@@ -203,9 +203,13 @@
 				<source>There are no unpublished changes in this workspace.</source>
         <target state="final">In diesem Arbeitsbereich gibt es keine unveröffentlichten Änderungen.</target>
       </trans-unit>
+      <trans-unit id="workspaces.discardSelectedChangesInWorkspaceConfirmation" xml:space="preserve" approved="yes">
+        <source>Do you really want to discard selected changes in the "{0}" workspace?</source>
+        <target state="final">Möchten Sie wirklich die ausgewählten Änderungen im Arbeitsbereich "{0}" verwerfen?</target>
+      </trans-unit>
       <trans-unit id="workspaces.discardAllChangesInWorkspaceConfirmation" xml:space="preserve" approved="yes">
-				<source>Do you really want to discard the changes in the "{0}" workspace?</source>
-        <target state="final">Möchten Sie die Änderungen im Arbeitsbereich "{0}" wirklich verwerfen?</target>
+        <source>Do you really want to discard all changes in the "{0}" workspace?</source>
+        <target state="final">Möchten Sie wirklich alle Änderungen im Arbeitsbereich "{0}" verwerfen?</target>
       </trans-unit>
       <trans-unit id="workspaces.workspaceWithThisTitleAlreadyExists" approved="yes">
         <source>A workspace with this title already exists.</source>

--- a/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
+++ b/Neos.Neos/Resources/Private/Translations/en/Modules.xlf
@@ -152,8 +152,11 @@
 			<trans-unit id="workspaces.thereAreNoUnpublishedChanges" xml:space="preserve">
 				<source>There are no unpublished changes in this workspace.</source>
 			</trans-unit>
+			<trans-unit id="workspaces.discardSelectedChangesInWorkspaceConfirmation" xml:space="preserve">
+				<source>Do you really want to discard selected changes in the "{0}" workspace?</source>
+			</trans-unit>
 			<trans-unit id="workspaces.discardAllChangesInWorkspaceConfirmation" xml:space="preserve">
-				<source>Do you really want to discard the changes in the "{0}" workspace?</source>
+				<source>Do you really want to discard all changes in the "{0}" workspace?</source>
 			</trans-unit>
 			<trans-unit id="workspaces.workspaceWithThisTitleAlreadyExists">
 				<source>A workspace with this title already exists.</source>


### PR DESCRIPTION
* Add dedicated modal to discard selected changes and make sure that it invokes the `discard` action
* Add a corresponding translation label for the confirmation dialog
* Change type of publish buttons from `primary` to `success`
* Fix HTML markup